### PR TITLE
Merge simulator-integration branch into main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Offer Uplift Simulator (Python) artifacts
+Offer Uplift Simulator/.venv/
+Offer Uplift Simulator/**/__pycache__/
+Offer Uplift Simulator/**/.pytest_cache/
+Offer Uplift Simulator/**/.mypy_cache/
+Offer Uplift Simulator/**/*.db

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ Used by `src/app/api/lead/route.ts`:
 - `LEAD_NOTIFY_EMAIL` (optional): Notification recipient. Defaults to `has.dhia@gmail.com`.
 - `LEADS_FROM_EMAIL` (optional): From address for Resend. Defaults to `onboarding@resend.dev`.
 
-For the simulator embed (optional):
+For the simulator embed (optional, choose one):
 
-- `NEXT_PUBLIC_SIMULATOR_URL` (optional): If set, `/simulator` will load this URL in an iframe. If not set, it falls back to `/simulator/index.html` so you can serve a static build under `public/simulator/`.
+- `NEXT_PUBLIC_SIMULATOR_URL`: Direct URL to the hosted simulator (loaded in an iframe)
+- `SIMULATOR_PROXY_ORIGIN`: Origin to proxy via Next.js rewrites (e.g., `https://simulator.example.com`). Then `/simulator` loads `/simulator-app` which proxies to that origin.
 
 Define these in `.env.local` for development and in Vercel Project Settings for production.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ Used by `src/app/api/lead/route.ts`:
 - `LEAD_NOTIFY_EMAIL` (optional): Notification recipient. Defaults to `has.dhia@gmail.com`.
 - `LEADS_FROM_EMAIL` (optional): From address for Resend. Defaults to `onboarding@resend.dev`.
 
+For the simulator embed (optional):
+
+- `NEXT_PUBLIC_SIMULATOR_URL` (optional): If set, `/simulator` will load this URL in an iframe. If not set, it falls back to `/simulator/index.html` so you can serve a static build under `public/simulator/`.
+
 Define these in `.env.local` for development and in Vercel Project Settings for production.
 
 
@@ -109,6 +113,7 @@ src/
 - `/diagnostic` – Growth diagnostic (client-side form posts to API)
 - `/resources` – Strategy OS resources
 - `/schedule` – Calendly booking
+- `/simulator` – Offer Uplift Simulator (iframe embed)
 - `/api/lead` – POST endpoint
 
 Example `POST /api/lead` payload (sent by the diagnostic page):

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,16 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "upload.wikimedia.org" },
     ],
   },
+  async rewrites() {
+    const origin = process.env.SIMULATOR_PROXY_ORIGIN;
+    if (!origin) return [];
+    const base = origin.replace(/\/$/, "");
+    return [
+      { source: "/simulator-app", destination: `${base}/` },
+      { source: "/simulator-app/", destination: `${base}/` },
+      { source: "/simulator-app/:path*", destination: `${base}/:path*` },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/simulator/loading.tsx
+++ b/src/app/simulator/loading.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from "../../components/ui/Skeleton";
+
+export default function Loading() {
+  return (
+    <section className="container section">
+      <div className="mb-4">
+        <div className="h-6 w-52"><Skeleton /></div>
+        <div className="h-8 w-80 mt-2"><Skeleton /></div>
+      </div>
+      <div className="rounded-2xl overflow-hidden border border-[hsl(var(--border))]">
+        <div className="aspect-[16/10] w-full bg-[hsl(var(--muted))]" />
+      </div>
+    </section>
+  );
+}
+
+

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -1,28 +1,56 @@
 "use client";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { SectionHeader } from "../../components/SectionHeader";
+import { Button } from "../../components/ui/Button";
 
 export default function SimulatorPage() {
   const src = useMemo(() => {
     if (typeof window === "undefined") return "";
-    const env = process.env.NEXT_PUBLIC_SIMULATOR_URL;
-    return env && env.length > 0 ? env : "/simulator/index.html";
+    const direct = process.env.NEXT_PUBLIC_SIMULATOR_URL;
+    if (direct && direct.length > 0) return direct;
+    // fallback: proxy via Next.js rewrite if SIMULATOR_PROXY_ORIGIN is set
+    return "/simulator-app";
   }, []);
+
+  const [failed, setFailed] = useState(false);
 
   return (
     <section className="container section">
       <SectionHeader kicker="Tool" title="Offer Uplift Simulator" subtitle="Model pricing, conversion, and margin sensitivities." useGradientTitle />
-      <div className="rounded-2xl overflow-hidden bg-[hsl(var(--card))] text-[hsl(var(--card-foreground))] border border-[hsl(var(--border))] shadow-sm">
-        <div className="aspect-[16/10] w-full">
-          <iframe
-            title="Offer Uplift Simulator"
-            src={src}
-            className="w-full h-full"
-            loading="eager"
-            referrerPolicy="no-referrer"
-          />
+
+      {src ? (
+        <div className="rounded-2xl overflow-hidden bg-[hsl(var(--card))] text-[hsl(var(--card-foreground))] border border-[hsl(var(--border))] shadow-sm">
+          <div className="aspect-[16/10] w-full relative">
+            <iframe
+              title="Offer Uplift Simulator"
+              src={src}
+              className="w-full h-full"
+              loading="eager"
+              referrerPolicy="no-referrer"
+              onError={() => setFailed(true)}
+            />
+            {failed && (
+              <div className="absolute inset-0 flex items-center justify-center p-6 text-center bg-[hsl(var(--background)/0.7)] backdrop-blur-sm">
+                <div>
+                  <p className="font-semibold">Could not load the simulator here.</p>
+                  <p className="text-sm text-[hsl(var(--muted-foreground))] mt-1">Some hosts block embedding. Open it in a new tab instead.</p>
+                  <div className="mt-3">
+                    <Button asChild variant="gradient"><a href={src} target="_blank" rel="noopener">Open Simulator</a></Button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      ) : (
+        <div className="rounded-2xl border border-[hsl(var(--border))] p-5 bg-[hsl(var(--card))] text-[hsl(var(--card-foreground))]">
+          <p className="font-semibold">Simulator URL not configured.</p>
+          <p className="text-sm text-[hsl(var(--muted-foreground))] mt-1">
+            Set <code>NEXT_PUBLIC_SIMULATOR_URL</code> in your environment to point to the deployed simulator. Alternatively, place a static build under <code>public/simulator/</code> and update this page to reference it.
+          </p>
+        </div>
+      )}
+
       <p className="mt-3 text-xs text-[hsl(var(--muted-foreground))]">
         If the simulator does not load, open it directly in a new tab.
       </p>

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { useMemo } from "react";
+import { SectionHeader } from "../../components/SectionHeader";
+
+export default function SimulatorPage() {
+  const src = useMemo(() => {
+    if (typeof window === "undefined") return "";
+    const env = process.env.NEXT_PUBLIC_SIMULATOR_URL;
+    return env && env.length > 0 ? env : "/simulator/index.html";
+  }, []);
+
+  return (
+    <section className="container section">
+      <SectionHeader kicker="Tool" title="Offer Uplift Simulator" subtitle="Model pricing, conversion, and margin sensitivities." useGradientTitle />
+      <div className="rounded-2xl overflow-hidden bg-[hsl(var(--card))] text-[hsl(var(--card-foreground))] border border-[hsl(var(--border))] shadow-sm">
+        <div className="aspect-[16/10] w-full">
+          <iframe
+            title="Offer Uplift Simulator"
+            src={src}
+            className="w-full h-full"
+            loading="eager"
+            referrerPolicy="no-referrer"
+          />
+        </div>
+      </div>
+      <p className="mt-3 text-xs text-[hsl(var(--muted-foreground))]">
+        If the simulator does not load, open it directly in a new tab.
+      </p>
+    </section>
+  );
+}
+
+

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useState, useEffect, useRef } from "react";
-import { Home, NotebookText, Rocket, Layers, FileText, Phone, Menu, X } from "lucide-react";
+import { Home, NotebookText, Rocket, Layers, FileText, Phone, Menu, X, Calculator } from "lucide-react";
 import { ThemeToggle } from "./ThemeToggle";
 import { AnimatePresence, m } from "framer-motion";
 import { durations, easings, overlayVariants } from "../lib/motion";
@@ -11,6 +11,7 @@ const links = [
   { href: "/offers", label: "Offers", icon: Rocket },
   { href: "/diagnostic", label: "Diagnostic", icon: NotebookText },
   { href: "/resources", label: "Resources", icon: Layers },
+  { href: "/simulator", label: "Simulator", icon: Calculator },
   { href: "/schedule", label: "Schedule", icon: Phone },
   { href: "https://linkedin.com", label: "Blog", icon: FileText, external: true },
 ];

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 // framer-motion not required here; keep CSS-based micro interactions for anchors
-import { Home, NotebookText, Rocket, Layers, FileText, Phone } from "lucide-react";
+import { Home, NotebookText, Rocket, Layers, FileText, Phone, Calculator } from "lucide-react";
 // Avoid passing Lucide component classes across the RSC boundary; render directly
 import { ThemeToggle } from "./ThemeToggle";
 import { useScrollspy } from "../hooks/useScrollspy";
@@ -12,6 +12,7 @@ const links = [
   { href: "/offers", label: "Offers", icon: Rocket },
   { href: "/diagnostic", label: "Diagnostic", icon: NotebookText },
   { href: "/resources", label: "Resources", icon: Layers },
+  { href: "/simulator", label: "Simulator", icon: Calculator },
   { href: "/schedule", label: "Schedule", icon: Phone },
   { href: "https://linkedin.com", label: "Blog", icon: FileText, external: true },
 ];


### PR DESCRIPTION
This pull request merges the `simulator-integration` branch into `main`.

Key updates:
- Adds the `/simulator` route and navigation link so the embedded simulator loads within the Next.js site.
- Introduces the `NEXT_PUBLIC_SIMULATOR_URL` environment variable to configure the external simulator's URL.
- Adds optional proxy support via `SIMULATOR_PROXY_ORIGIN`.
- Updates documentation for the simulator route and environment variables.
- Implements robust iframe fallback and proxy rewrites to handle cross-origin embedding.
- Cleans up local Python artifacts via `.gitignore`.

These changes enable `https://smarttechinvest.com/simulator` to embed the Flask simulator hosted at an external URL, with support for proxying through the main domain.